### PR TITLE
Fixes Off by one error in Chrome, (or my code, either or this is beneficial to the user imo)

### DIFF
--- a/src/scrollglue.js
+++ b/src/scrollglue.js
@@ -25,7 +25,7 @@
                 }
 
                 function shouldActivateAutoScroll(){
-                    return el.scrollTop + el.clientHeight == el.scrollHeight;
+                    return el.scrollTop + el.clientHeight + 3 >= el.scrollHeight;
                 }
 
                 scope.$watch(function(){


### PR DESCRIPTION
Chrome was reporting the value el.scrollTop + el.clientHeight as one less than reality. This adds 3 to the value (just to be sure) and checks for greater than or equal and returns true in a greater range. This has the added benefit of anticipating the intentions of the user if they don't quite make it to the exact bottom of the element. (I may actually raise this value to exploit this further.)
