### PR TITLE
Enabled scroll-glue to work on the body element.

### DIFF
--- a/src/scrollglue.js
+++ b/src/scrollglue.js
@@ -78,8 +78,22 @@
                     activationState.setValue(shouldActivateAutoScroll());
                 }
 
+                function shouldActivateAutoScrollForWindow(){
+                    var scrollTop = (document.documentElement && document.documentElement.scrollTop) || document.body.scrollTop;
+                    return (scrollTop + window.innerHeight) >= document.body.scrollHeight;
+                }
+
+                function onScrollWindow() {
+                    activationState.setValue(shouldActivateAutoScrollForWindow());
+                }
+
                 scope.$watch(onScopeChanges);
-                $el.bind('scroll', onScroll);
+                
+                if(el.constructor.name === HTMLBodyElement.name) {
+                    window.onscroll = onScrollWindow;
+                } else {
+                    el.bind('scroll', onScroll);
+                }
             }
         };
     }]);


### PR DESCRIPTION
Hi,

I made scroll-glue work on body elements. In that case you've to register on the `window.onscroll` event. The calculation in `shouldActivateAutoScroll()` is a bit different to normal elements, too.

I tried to create karma tests for the extended behavior, but if I understand it correctly, the compiled templates will be appended below the body element. That would result in two nested body tags, which obviously doesn't work.

Kind regards
Marcell
