### PR TITLE
Fixed ungluing scrollbar in firefox

### DIFF
--- a/src/scrollglue.js
+++ b/src/scrollglue.js
@@ -64,7 +64,7 @@
                 }
 
                 function onScopeChanges(scope){
-                    if(activationState.getValue()){
+                    if(activationState.getValue() && !shouldActivateAutoScroll()){
                         scrollToBottom();
                     }
                 }


### PR DESCRIPTION
We found issue using angular-scroll-glue on latest updates of Firefox browser (version 34). The problem was that scrollbars on Firefox are less sensitive than on Chrome. This led to following problem, that scroll event was cancelled in onScopeChanges before it was triggered. This led to impossibility of scrollbar movement and scrollbar always stayed glued to the bottom of the page.  

This fix solved this problem by rechecking the scroller position even in onScopeChanges. We tested this solution on Chrome, Firefox and IE. It works as expected now.
