### PR TITLE
Fix memory leak - remove listeners when directive destroyed

### DIFF
--- a/src/scrollglue.js
+++ b/src/scrollglue.js
@@ -71,14 +71,26 @@
                         }
                     }
 
+                    function onScroll() {
+                        activationState.setValue(direction.isAttached(el));
+                    }
+
                     scope.$watch(scrollIfGlued);
-                    
+
                     $timeout(scrollIfGlued, 0, false);
-                    
+
                     $window.addEventListener('resize', scrollIfGlued, false);
 
-                    $el.bind('scroll', function(){
-                        activationState.setValue(direction.isAttached(el));
+                    $el.bind('scroll', onScroll);
+
+
+                    // Remove listeners on directive destroy
+                    $el.on('$destroy', function() {
+                        $el.unbind('scroll', onScroll);
+                    });
+
+                    scope.$on('$destroy', function() {
+                        $window.removeEventListener('resize',scrollIfGlued, false);
                     });
                 }
             };


### PR DESCRIPTION
Remove $window and $el listeners when directive is destroyed. This fixes a memory leak I had to struggle with.